### PR TITLE
Version for CITE test suites changed:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,21 @@
   <repositories>
     <repository>
       <id>osgeo</id>
-      <name>Open Source Geospatial Foundation Repository</name>
-      <url>http://download.osgeo.org/webdav/geotools/</url>
-      <!-- release repository used by geotools (and third-party dependencies) -->
+      <name>OSGeo Nexus Release Repository</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
+      <!-- contains release (including third-party-dependences)                            -->
+      <!-- ucar (https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases) -->
+      <!-- geosolutions (http://maven.geo-solutions.it/)                                   -->
+      <snapshots><enabled>false</enabled></snapshots>
+      <releases><enabled>true</enabled></releases>
+    </repository>
+
+    <repository>
+      <id>osgeo-snapshot</id>
+      <name>OSGeo Nexus Snapshot Repository</name>
+      <url>https://repo.osgeo.org/repository/snapshot/</url>
+      <snapshots><enabled>true</enabled></snapshots>
+      <releases><enabled>false</enabled></releases>
     </repository>
   </repositories>
 

--- a/teamengine-beta/pom.xml
+++ b/teamengine-beta/pom.xml
@@ -14,14 +14,14 @@
     <teamengine.version>5.3</teamengine.version>
     <ets-wcs10.version>1.15</ets-wcs10.version>
     <ets-wcs11.version>1.13</ets-wcs11.version>
-    <ets-wcs20.version>1.14</ets-wcs20.version>
+    <ets-wcs20.version>1.15</ets-wcs20.version>
     <ets-wfs10.version>1.12</ets-wfs10.version>
     <ets-wfs11.version>1.32</ets-wfs11.version>
-    <ets-wfs20.version>1.30</ets-wfs20.version>
+    <ets-wfs20.version>1.32</ets-wfs20.version>
     <ets-wfs30.version>0.2</ets-wfs30.version>
     <ets-wms11.version>1.19</ets-wms11.version>
     <ets-wms13.version>1.25</ets-wms13.version>
-    <ets-wmts10.version>1.2</ets-wmts10.version>
+    <ets-wmts10.version>1.3</ets-wmts10.version>
     <ets-csw202.version>1.18</ets-csw202.version>
     <ets-cat30.version>1.2</ets-cat30.version>
     <ets-gml32.version>1.26</ets-gml32.version>


### PR DESCRIPTION
CITE Suite version changed:
- ets-wcs20 = 1.15
- ets-wfs20 = 1.32
- ets-wmts10 = 1.3

Repositories for CITE test changed:
- OSGeo Nexus Release Repository
- OSGeo Nexus Snapshot Repository